### PR TITLE
fix build with network-3.0

### DIFF
--- a/hstatsd.cabal
+++ b/hstatsd.cabal
@@ -20,5 +20,5 @@ Library
   build-depends:        base >= 3 && < 5,
                         bytestring,
                         mtl,
-                        network,
+                        network >= 2.4,
                         text

--- a/src/Network/StatsD.hs
+++ b/src/Network/StatsD.hs
@@ -70,4 +70,4 @@ fmtMany prefix = map (T.encodeUtf8 . fmt prefix)
 
 push statsd = mapM_ (BL.sendAll (connection statsd)) . segment . fmtMany (prefix statsd)
 
-closeStatsD = sClose . connection
+closeStatsD = close . connection


### PR DESCRIPTION
- the function `sClose` has been synonymous with `close` ever since
  network-2.4.0.0, and was finally removed in network-3.0.0.0